### PR TITLE
Verify wordlist path with `open` before reading from file

### DIFF
--- a/crackhash.py
+++ b/crackhash.py
@@ -31,8 +31,7 @@ try:
     # Attempt to 'read' password file.
     open(PASSWORD_FILE, 'r', 'latin-1')
 except FileNotFoundError:
-    raise FileNotFoundError("{} does not exist. Install the rockyou.txt
-    word list from an online source.")
+    raise FileNotFoundError("{} does not exist. Install the rockyou.txt word list from an online source.")
 
 attempts = 0
 

--- a/crackhash.py
+++ b/crackhash.py
@@ -24,13 +24,22 @@ if len(sys.argv) != 2:
     exit()
 
 wanted_hash = sys.argv[1]
-password_file = "/usr/share/wordlists/rockyou.txt"
+
+PASSWORD_FILE = "/usr/share/wordlists/rockyou.txt"
+
+try:
+    # Attempt to 'read' password file.
+    open(PASSWORD_FILE, 'r', 'latin-1')
+except FileNotFoundError:
+    raise FileNotFoundError("{} does not exist. Install the rockyou.txt
+    word list from an online source.")
+
 attempts = 0
 
 display_banner()
 
 with log.progress("Attempting to crack: {}!\n".format(wanted_hash)) as p:
-    with open(password_file, "r", encoding='latin-1') as password_list:
+    with open(PASSWORD_FILE, "r", encoding='latin-1') as password_list:
         for password in password_list:
             password = password.strip("\n").encode('latin-1')
             password_hash = sha256sumhex(password)

--- a/crackhash.py
+++ b/crackhash.py
@@ -48,8 +48,9 @@ with log.progress("Attempting to crack: {}!\n".format(wanted_hash)) as p:
 
             if password_hash == wanted_hash:
                 p.success("[+] Password hash found after {} attempts!\n [+] Plaintext found: {}\n [+] from the hash {}!".format(attempts, password.decode('latin-1'), password_hash))
-                exit()
+                sys.exit(0)
 
             attempts += 1
 
     p.failure("[-] Password Hash Not Found")
+    sys.exit(1)

--- a/crackhash.py
+++ b/crackhash.py
@@ -29,7 +29,7 @@ PASSWORD_FILE = "/usr/share/wordlists/rockyou.txt"
 
 try:
     # Attempt to 'read' password file.
-    open(PASSWORD_FILE, 'r', 'latin-1')
+    open(PASSWORD_FILE, 'r', encoding='latin-1')
 except FileNotFoundError:
     raise FileNotFoundError("{} does not exist. Install the rockyou.txt word list from an online source.")
 


### PR DESCRIPTION
### Changes
* Verify file path
The file path is verified. If the file does not exist, it throws a `FileNotFoundError`.
* Replaces `exit()` with `sys.exit(...)` to utilize exit codes
When the program exits with an error, the exit status is `1`. Otherwise, `crackhash.py` exits with the status code `0`.

### Suggestions
* Move the banner into a different file and do something like:
```python
banner = open('./.banner', 'r')
# display the `banner` file stream
```
* Move the code into one `main()` function. The `main()` function is then called upon the verification of global 'dunder' constants as follows:
```python
def main():
   # All the code that is not already inside of a function
   # ...

# Conditional for the global scope
if __name__ == "__main__":
    main()